### PR TITLE
Workflow for Checking that Proc Names are Prefixed with their Containing File Names

### DIFF
--- a/.github/workflows/proc-name-check.yml
+++ b/.github/workflows/proc-name-check.yml
@@ -1,0 +1,22 @@
+name: 'Proc Name Check'
+
+on:
+  pull_request:
+    paths:
+      - '**.tcl'
+
+jobs:
+  proc-name-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependencies
+        run: |
+          sudo apt-get update && sudo apt-get -y install tclsh tcllib tdom tclcurl libpgtcl
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Check Line Length
+        run: |
+          cd scripts
+          tclsh proc-name-check.tcl "*.tcl"

--- a/scripts/proc-name-check.tcl
+++ b/scripts/proc-name-check.tcl
@@ -1,0 +1,26 @@
+set incorrect_names false
+
+foreach file [glob [lindex $argv 0]] {
+    set handle [open $file r]
+    set contents [read $handle]
+    set line_no 1
+    set filename [file tail $file]
+    set length [string length [file extension $file]]
+    set prefix [string range $filename 0 end-$length]
+
+    foreach line [split $contents "\n"] {
+        if { [regexp {^\s*proc\s(.+)\s+\{} $line -> proc_name]
+             && ![string match "${prefix}*" $proc_name] } {
+            puts "$filename :: Line $line_no :: $proc_name"
+            set incorrect_names true
+        }
+
+        incr line_no
+    }
+
+    close $handle
+}
+
+if { $incorrect_names } {
+    exit 1
+}


### PR DESCRIPTION
This action will run on pull requests that have changed any Tcl files. It'll go through all files and check that proc names within the file are prefixed with the file name (except the file extension). Any failing proc names will be logged and visible in the action log.

This iteration **does not** take into account namespaces and ensembles so they will fail the check.