### PR TITLE
Checkout Qcode CI in Reusable Workflows

### DIFF
--- a/.github/workflows/line-length-check.yml
+++ b/.github/workflows/line-length-check.yml
@@ -27,6 +27,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout Qcode CI
+        uses: actions/checkout@v3
+        with:
+          repository: qcode-software/ci-development
+          path: qcode-ci
+
       - name: Get Changed Tcl Script Files
         id: changed-files
         uses: tj-actions/changed-files@v34
@@ -38,7 +44,7 @@ jobs:
         run: |
           echo "Checking line length is under ${{ inputs.max_line_length }} chars \
           in files: ${{ steps.changed-files.outputs.all_changed_files }}"
-          cd ~/ci-development/scripts
+          cd ${{ github.workspace }}/qcode-ci/scripts
           tclsh line-length-check.tcl \
             ${{ inputs.max_line_length }} \
             ${{ github.workspace }} \

--- a/.github/workflows/line-length-check.yml
+++ b/.github/workflows/line-length-check.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: qcode-software/ci-development
-          ref: checkout-qcode-ci
           path: qcode-ci
 
       - name: Get Changed Tcl Script Files

--- a/.github/workflows/line-length-check.yml
+++ b/.github/workflows/line-length-check.yml
@@ -46,6 +46,7 @@ jobs:
           in files: ${{ steps.changed-files.outputs.all_changed_files }}"
           cd ${{ github.workspace }}/qcode-ci/scripts
           tclsh line-length-check.tcl \
+            ${{ github.workspace }}/qcode-ci/tcl/linter.tcl
             ${{ inputs.max_line_length }} \
             ${{ github.workspace }} \
             ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/line-length-check.yml
+++ b/.github/workflows/line-length-check.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: qcode-software/ci-development
+          ref: checkout-qcode-ci
           path: qcode-ci
 
       - name: Get Changed Tcl Script Files

--- a/.github/workflows/proc-name-check.yml
+++ b/.github/workflows/proc-name-check.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout Qcode CI
+        uses: actions/checkout@v3
+        with:
+          repository: qcode-software/ci-development
+          path: qcode-ci
+
       - name: Get Changed Tcl Script Files
         id: changed-files
         uses: tj-actions/changed-files@v34
@@ -33,7 +39,7 @@ jobs:
         run: |
           echo "Checking proc name prefixes in files: \
             ${{ steps.changed-files.outputs.all_changed_files }}"
-          cd ~/ci-development/scripts
+          cd ${{ github.workspace }}/qcode-ci/scripts
           tclsh proc-name-check.tcl \
             ${{ github.workspace }} \
             ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/proc-name-check.yml
+++ b/.github/workflows/proc-name-check.yml
@@ -41,5 +41,6 @@ jobs:
             ${{ steps.changed-files.outputs.all_changed_files }}"
           cd ${{ github.workspace }}/qcode-ci/scripts
           tclsh proc-name-check.tcl \
+            ${{ github.workspace }}/qcode-ci/tcl/linter.tcl
             ${{ github.workspace }} \
             ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/proc-name-check.yml
+++ b/.github/workflows/proc-name-check.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: qcode-software/ci-development
+          ref: checkout-qcode-ci
           path: qcode-ci
 
       - name: Get Changed Tcl Script Files

--- a/.github/workflows/proc-name-check.yml
+++ b/.github/workflows/proc-name-check.yml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: qcode-software/ci-development
-          ref: checkout-qcode-ci
           path: qcode-ci
 
       - name: Get Changed Tcl Script Files

--- a/scripts/line-length-check.tcl
+++ b/scripts/line-length-check.tcl
@@ -1,9 +1,10 @@
-set max_line_length [lindex $argv 0]
-set repository [lindex $argv 1]
-set files [lrange $argv 2 end]
+set linter [lindex $argv 0]
+set max_line_length [lindex $argv 1]
+set repository [lindex $argv 2]
+set files [lrange $argv 3 end]
 set long_lines [list]
 
-source "${repository}/tcl/linter.tcl"
+source $linter
 
 foreach file $files {
     set lines [linter_report_lines_over_length \

--- a/scripts/proc-name-check.tcl
+++ b/scripts/proc-name-check.tcl
@@ -1,8 +1,9 @@
-set repository [lindex $argv 0]
-set files [lrange $argv 1 end]
+set linter [lindex $argv 0]
+set repository [lindex $argv 1]
+set files [lrange $argv 2 end]
 set reported_procs [list]
 
-source "${repository}/tcl/linter.tcl"
+source $linter
 
 foreach file $files {
     set lines [linter_report_procs_without_filename_prefix \


### PR DESCRIPTION
Checking out the CI repo will make the scripts and linter Tcl files available to any repo that reuses these workflows.