### PR TITLE
Proc Length Check

### DIFF
--- a/.github/workflows/proc-length-check.yml
+++ b/.github/workflows/proc-length-check.yml
@@ -1,0 +1,52 @@
+name: 'Proc Length Check'
+
+on:
+  workflow_call:
+    inputs:
+      files:
+        description: 'List of files to check for changes.'
+        required: true
+        type: string
+      max_proc_body_length:
+        description: 'The maximum number of lines that a proc body can be.' 
+        default: 150
+        required: false
+        type: number
+
+jobs:
+  proc-length-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install tclsh tcllib tdom tclcurl libpgtcl
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Checkout Qcode CI
+        uses: actions/checkout@v3
+        with:
+          repository: qcode-software/ci-development
+          path: qcode-ci
+
+      - name: Get Changed Tcl Script Files
+        id: changed-files
+        uses: tj-actions/changed-files@v34
+        with:
+          files: ${{ inputs.files }}
+
+      - name: Check Proc Lengths
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          echo "Checking proc body lengths in files: \
+            ${{ steps.changed-files.outputs.all_changed_files }}"
+          cd ${{ github.workspace }}/qcode-ci/scripts
+          tclsh proc-length-check.tcl \
+            ${{ github.workspace }}/qcode-ci/tcl/linter.tcl \
+            ${{ inputs.max_proc_body_length }} \
+            ${{ github.workspace }} \
+            ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -16,8 +16,10 @@ jobs:
       test_directory: tests
       max_line_length: 90
       max_file_length: 300
+      max_proc_body_length: 100
       check_line_lengths: true
       check_proc_names: true
       check_procs_have_unit_tests: true
       check_file_lengths: true
+      check_proc_lengths: true
     secrets: inherit

--- a/.github/workflows/qcode-ci.yml
+++ b/.github/workflows/qcode-ci.yml
@@ -13,6 +13,11 @@ on:
         default: 500
         required: false
         type: number
+      max_proc_body_length:
+        description: 'The maximum number of lines that a proc body can be.' 
+        default: 150
+        required: false
+        type: number
       check_line_lengths:
         description: 'Flag for checking line lengths.'
         default: true
@@ -30,6 +35,11 @@ on:
         type: boolean
       check_file_lengths:
         description: 'Flag for checking file lengths.'
+        default: true
+        required: false
+        type: boolean
+      check_proc_lengths:
+        description: 'Flag for checking proc body lengths.'
         default: true
         required: false
         type: boolean
@@ -58,6 +68,15 @@ jobs:
     if: inputs.check_proc_names
     uses: ./.github/workflows/proc-name-check.yml
     with:
+      files: ${{ inputs.files }}
+    secrets: inherit
+
+  proc_length_check:
+    name: Check for Proc Bodies Exceeding Max Lines
+    if: inputs.check_proc_lengths
+    uses: ./.github/workflows/proc-length-check.yml
+    with:
+      max_proc_body_length: ${{ inputs.max_proc_body_length }}
       files: ${{ inputs.files }}
     secrets: inherit
 

--- a/scripts/proc-length-check.tcl
+++ b/scripts/proc-length-check.tcl
@@ -1,0 +1,30 @@
+set linter [lindex $argv 0]
+set max_lines [lindex $argv 1]
+set repository [lindex $argv 2]
+set files [lrange $argv 3 end]
+set long_procs [list]
+
+source $linter
+
+foreach file $files {
+    set proc_lengths [linter_file_proc_lengths "${repository}/${file}"]
+
+    dict for {proc_name body_length} $proc_lengths {
+        if { $body_length > $max_lines } {
+            dict set long_procs $file $proc_name $body_length
+        }
+    }
+}
+
+if { [dict size $long_procs] > 0 } {
+
+    puts "Procs with bodies greater than ${max_lines} lines:"
+
+    dict for {filename procs} $long_procs {
+        dict for {proc_name body_length} $procs {
+            puts "  $filename :: $proc_name :: $body_length lines"
+        }
+    }
+
+    exit 1
+}

--- a/tcl/linter.tcl
+++ b/tcl/linter.tcl
@@ -76,3 +76,145 @@ proc linter_proc_names_parse {string} {
 
     return $proc_names
 }
+
+# proc linter_procs_get {string} {
+
+#     set lines [split $string "\n"]
+#     set pattern {^\s*proc\s+:{0,2}(?:[a-z0-9_-]+::)*(?:[a-z0-9_-]+)\s+}
+#     set line_no 1
+#     set procs_starts [list]
+
+#     foreach line $lines {
+#         if { [regexp $pattern $line] } {
+#             lappend procs_starts $line_no
+#         }
+
+#         incr line_no
+#     }
+
+#     set proc_lines [list]
+#     set count [llength $proc_starts]
+
+#     if { [llength $procs_starts] == 1} {
+#         set proc_ends $line_no
+#     }
+# }
+
+# proc linter_proc_body_length {contents} {
+#     # Get indexes of proc definitions.
+#     # Need to parse:
+#     # "proc"
+#     # proc name
+#     # arguments
+#     # body
+
+#     # Proc line count begins at body start.
+
+#     # What if "{" appears in a string somewhere?
+#     #   Would it always be preceded by a backslash?
+
+#     set paren_count 0
+#     set end_index 0
+
+#     foreach character [split [string trim $contents] ""] {
+#         if { $character eq "{" } {
+#             incr paren_count
+#         } elseif { $character eq "}" } {
+#             incr paren_count -1
+#         }
+
+#         if { $paren_count == 0 } {
+#             incr end_index
+#         }
+#     }
+# }
+
+proc linter_tcl_commands {script} {
+    #| Get Tcl commands that are in the script.
+    #|
+    #| Original author: PYK.
+    #| https://wiki.tcl-lang.org/page/cmdSplit
+
+    namespace upvar [namespace current] commands_info report
+    set report {}
+    set commands {}
+    set command {}
+    set comment 0
+    set lineidx 0
+    set offset 0
+    foreach line [split $script \n] {
+        set parts [split $line \;]
+        set numparts [llength $parts]
+        set partidx 0
+        while 1 {
+            set parts [lassign $parts[set parts {}] part]
+            if {[string length $command]} {
+                if {$partidx} {
+                    append command \;$part
+                } else {
+                    append command \n$part
+                }
+            } else {
+                set partlength [string length $part]
+                set command [string trimleft $part[set part {}] "\f\n\r\t\v "]
+                incr offset [expr {$partlength - [string length $command]}]
+                if {[string match #* $command]} {
+                    set comment 1
+                }
+            }
+
+            if {$command eq {}} {
+                incr offset
+            } elseif {(!$comment || (
+                    $comment && (!$numparts || ![llength $parts])))
+                && [info complete $command\n]} {
+
+                lappend commands $command
+                set info [dict create character $offset line $lineidx]
+                set offset [expr {$offset + [string length $command] + 1}]
+                lappend report $info
+                set command {}
+                set comment 0
+                set info {}
+            }
+
+            incr partidx
+            if {![llength $parts]} break
+        }
+    }
+
+    incr lineidx
+
+    if {$command ne {}} {
+        error [list {incomplete command} $command]
+    }
+
+    return $commands
+}
+
+proc linter_proc_lengths {file} {
+
+    try {
+        set handle [open $file r]
+        set contents [read $handle]
+        set commands [linter_tcl_commands $contents]
+        set proc_lengths [dict create]
+
+        foreach command $commands {
+            if { [lindex $command 0] eq "proc" } {
+                set proc_name [lindex $command 1]
+                set body_length [llength [split [string trim [lindex $command 3]] "\n"]]
+
+                dict set proc_lengths $proc_name $body_length
+            }
+        }
+
+        return $proc_lengths
+    } on error [list message options] {
+        error $message [dict get $options -errorinfo] [dict get $options -errorcode]
+    } finally {
+        if { [info exists handle] } {
+            close $handle
+        }
+    }
+}

--- a/tests/tcl/linter.test
+++ b/tests/tcl/linter.test
@@ -64,4 +64,108 @@ test linter_proc_names_parse-1.0 \
     } \
     -result 1
 
+test linter_tcl_commands-1.0 \
+    {Get the Tcl commands from a string.} \
+    -setup $setup \
+    -body {
+        set test {
+            proc test_1 {args} {
+                # This is a test proc.
+                return 1
+            }
+
+            set foo "bar"
+        }
+
+        set commands [linter_tcl_commands $test]
+
+        set command1 [lindex $commands 0]
+        set command2 [lindex $commands 1]
+
+        if { [lindex $command1 0] ne "proc" } {
+            error "Expected proc but got [lindex $command1 0]."
+        }
+
+        if { [lindex $command1 1] ne "test_1" } {
+            error "Expected test_1 but got [lindex $command1 1]."
+        }
+
+        if { [llength [lindex $command1 2]] != 1
+             || [lindex [lindex $command1 2] 0] ne "args" } {
+            error "Expected {args} but got [lindex $command1 2]."
+        }
+
+        if { [llength [split [string trim [lindex $command1 3]] "\n"]] != 2 } {
+            error "Expected 2 lines in proc test_1 body but got\
+                   [string trim [lindex $command1 3]]."
+        }
+
+        if { $command2 ne {set foo "bar"} } {
+            error "Expected {set foo "bar"} but got $command2."
+        }
+
+        return 1
+    } \
+    -result 1
+
+test linter_proc_lengths-1.0 \
+    {Get body length of procs in a string.} \
+    -setup $setup \
+    -body {
+        set test {
+            proc test_1 {args} {
+                # This is a test proc.
+                return 1
+            }
+
+            proc test_2 {} {
+                set foo 1
+                set bar 2
+
+                return [expr {$foo + $bar}]
+            }
+
+            namespace eval tests {
+
+                namespace export test_3
+
+                namespace ensemble create
+
+                proc test_3 {args} {
+                    #| Ensemble proc.
+
+                    return "a"
+                }
+            }
+
+            namespace eval test_vars {
+                set vars [list]
+                lappend vars \
+                    [dict create \
+                         a 1 \
+                         b 2 \
+                         c 3] \
+                    [dict create \
+                         a 4 \
+                         b 5 \
+                         c 6]
+
+                proc test_4 {args} {
+                    return 4
+                }
+            }
+        }
+
+        return [linter_proc_lengths $test]
+    } \
+    -result {test_1 2 test_2 4 test_3 3 test_4 1}
+
+test linter_file_proc_lengths-1.0 \
+    {Get body length of procs in a file.} \
+    -setup $setup \
+    -body {
+        return [linter_file_proc_lengths $test_file] 
+    } \
+    -result {this_is_a_long_proc_name_for_testing 5 linter_test 3 linter_test_two 3 does_not_start_with_linter_test 3}
+
 cleanupTests


### PR DESCRIPTION
I'm not sure what we would consider too long for proc bodies. I've set the default for the workflow to 150 lines and the default for this project to 100 lines. It can be customised per project for anyone who uses the workflow.

Testing
---
```
tclsh tcl/linter.test
linter.test:	Total	6	Passed	6	Skipped	0	Failed	0
```
### Feedback
![image](https://user-images.githubusercontent.com/8330836/220172185-56b62beb-c801-4d73-8438-0aa535352b38.png)
