### PR TITLE
Check Procs Have a #| Comment

### DIFF
--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -22,4 +22,5 @@ jobs:
       check_procs_have_unit_tests: true
       check_file_lengths: true
       check_proc_lengths: true
+      check_proc_comments: true
     secrets: inherit

--- a/.github/workflows/qcode-ci.yml
+++ b/.github/workflows/qcode-ci.yml
@@ -155,7 +155,7 @@ jobs:
             ${{ github.workspace }} \
             ${{ steps.changed-files.outputs.all_changed_files }}
 
-      - name: Check Procs Have #| Comments
+      - name: 'Check Procs Have #| Comments'
         if: >
           always()
           && steps.changed-files.outcome == 'success'

--- a/.github/workflows/qcode-ci.yml
+++ b/.github/workflows/qcode-ci.yml
@@ -44,7 +44,7 @@ on:
         required: false
         type: boolean
       check_proc_comments:
-        description: 'Flag for checking procs begin with a #| comment.'
+        description: 'Flag for checking that procs have a #| comment.'
         default: true
         required: false
         type: boolean

--- a/.github/workflows/qcode-ci.yml
+++ b/.github/workflows/qcode-ci.yml
@@ -43,6 +43,11 @@ on:
         default: true
         required: false
         type: boolean
+      check_proc_comments:
+        description: 'Flag for checking procs begin with a #| comment.'
+        default: true
+        required: false
+        type: boolean
       files:
         description: 'List of files to check for changes.'
         required: true
@@ -147,5 +152,18 @@ jobs:
           tclsh file-length-check.tcl \
             ${{ github.workspace }}/qcode-ci/tcl/linter.tcl \
             ${{ inputs.max_file_length }} \
+            ${{ github.workspace }} \
+            ${{ steps.changed-files.outputs.all_changed_files }}
+
+      - name: Check Procs Have #| Comments
+        if: >
+          always()
+          && steps.changed-files.outcome == 'success'
+          && inputs.check_proc_comments
+          && steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          cd ${{ github.workspace }}/qcode-ci/scripts
+          tclsh proc-comment-check.tcl \
+            ${{ github.workspace }}/qcode-ci/tcl/linter.tcl \
             ${{ github.workspace }} \
             ${{ steps.changed-files.outputs.all_changed_files }}

--- a/scripts/linting.tcl
+++ b/scripts/linting.tcl
@@ -198,4 +198,4 @@ puts [linter_report_procs_without_proc_comment $tcl_files]
 set count [linter_count_procs_without_proc_comment $tcl_files]
 
 puts ""
-puts "$count procs that do not have a #| comment."
+puts "$count procs that do not have a #| comment found."

--- a/scripts/linting.tcl
+++ b/scripts/linting.tcl
@@ -139,7 +139,7 @@ puts "$count files exceeding $file_length lines found."
 puts ""
 puts "--------------------------------------------------"
 puts ""
-puts "Checking line length is under $line_length characters."
+puts "Checking for lines longer than $line_length characters."
 puts "---"
 
 puts [linter_report_lines_over_length $tcl_files $line_length]
@@ -186,3 +186,16 @@ set count [test_coverage_count_procs_without_unit_tests $tcl_files $test_files]
 
 puts ""
 puts "$count procs that do not have a unit test found."
+
+# Report procs without a #| comment.
+puts ""
+puts "--------------------------------------------------"
+puts ""
+puts "Checking for procs that do not have a #| comment."
+puts "---"
+
+puts [linter_report_procs_without_proc_comment $tcl_files]
+set count [linter_count_procs_without_proc_comment $tcl_files]
+
+puts ""
+puts "$count procs that do not have a #| comment."

--- a/scripts/proc-comment-check.tcl
+++ b/scripts/proc-comment-check.tcl
@@ -1,0 +1,15 @@
+set linter [lindex $argv 0]
+set repository [lindex $argv 1]
+set files [lrange $argv 2 end]
+
+source $linter
+
+puts "Checking procs begin with a #| comment in files that have changed."
+
+set tcl_files [lmap x $files {file join $repository $x}]
+puts [linter_report_procs_without_proc_comment $tcl_files]
+set count [linter_count_procs_without_proc_comment $tcl_files]
+
+if { $count > 0 } {
+    exit 1
+}

--- a/scripts/proc-comment-check.tcl
+++ b/scripts/proc-comment-check.tcl
@@ -4,7 +4,7 @@ set files [lrange $argv 2 end]
 
 source $linter
 
-puts "Checking procs begin with a #| comment in files that have changed."
+puts "Checking procs have a #| comment in files that have changed."
 
 set tcl_files [lmap x $files {file join $repository $x}]
 puts [linter_report_procs_without_proc_comment $tcl_files]

--- a/tcl/linter.tcl
+++ b/tcl/linter.tcl
@@ -365,7 +365,7 @@ proc linter_report_procs_without_proc_comment {files} {
 }
 
 proc linter_count_procs_without_proc_comment {files} {
-    #| Report procs that do not have a comment at the beginning of the body.
+    #| Count the number of procs without a description at the beginning of the body.
 
     set count 0
 

--- a/tcl/linter.tcl
+++ b/tcl/linter.tcl
@@ -328,21 +328,20 @@ proc linter_procs_without_proc_comment {string} {
     set commands [linter_tcl_commands $string]
 
     foreach command $commands {
-        switch -regexp $command {
-            {^proc} {
-                lassign $command proc proc_name args body
-                set body_lines [split [string trim $body] "\n"]
+        set command_name [lindex $command 0]
 
-                if { [lsearch -regexp $body_lines {^#\|}] == -1 } {
-                    lappend procs $proc_name
-                }
+        if { $command_name eq "proc" } {
+            lassign $command command_name proc_name args body
+            set body_lines [split [string trim $body] "\n"]
+
+            if { [lsearch -regexp $body_lines {^#\|}] == -1 } {
+                lappend procs $proc_name
             }
-            {^namespace} {
-                lassign $command namespace subcommand name body
+        } elseif { $command_name eq "namespace" } {
+            lassign $command command_name subcommand namespace body
 
-                if { $subcommand eq "eval" } {
-                    lappend procs {*}[linter_procs_without_proc_comment $body]
-                }
+            if { $subcommand eq "eval" } {
+                lappend procs {*}[linter_procs_without_proc_comment $body]
             }
         }
     }

--- a/tests/tcl/files/linter_test.tcl
+++ b/tests/tcl/files/linter_test.tcl
@@ -23,3 +23,7 @@ proc does_not_start_with_linter_test {args} {
 
     return "Hello World"
 }
+
+proc linter_test_no_comment {args} {
+    return "Hello World"
+}

--- a/tests/tcl/linter.test
+++ b/tests/tcl/linter.test
@@ -327,11 +327,12 @@ test linter_count_procs_over_length-1.0 \
     } \
     -result 1
 
-test linter_procs_first_line-1.0 \
-    {Test that procs without a #| comment are reported.} \
+test linter_procs_without_proc_comment-1.0 \
+    {Get procs that don't have a proc comment.} \
     -body {
-        set proc_lines [linter_procs_first_line {
+        set procs [linter_procs_without_proc_comment {
             proc test_1 {args} {
+
                 #| Test 1 proc.
                 return 1
             }
@@ -355,22 +356,16 @@ test linter_procs_first_line-1.0 \
             }
         }]
 
-        if { [dict size $proc_lines] != 4 } {
-            error "Expected 4 procs but got [dict size $proc_lines]."
+        if { [llength $procs] != 2 } {
+            error "Expected 2 procs but got [llength $procs]: $procs."
         }
 
-        set expected [dict create \
-                          test_1 {#| Test 1 proc.}\
-                          test_2 {return 2} \
-                          test_3 {#| Test 3 proc.} \
-                          test_4 {return 4}]
+        if { "test_2" ni $procs } {
+            error "Proc test_2 not found."
+        }
 
-        dict for {proc_name line} $proc_lines {
-            if { ![dict exists $expected $proc_name] } {
-                error "Proc \"$proc_name\" not expected."
-            } elseif { $line ne [dict get $expected $proc_name] } {
-                error "Expected \"[dict get $expected $proc_name]\" but got \"$line\"."
-            }
+        if { "test_4" ni $procs } {
+            error "Proc test_4 not found."
         }
 
         return 1
@@ -378,7 +373,7 @@ test linter_procs_first_line-1.0 \
     -result 1
 
 test linter_report_procs_without_proc_comment-1.0 \
-    {Test that procs without a #| comment are reported.} \
+    {Report procs without a proc comment.} \
     -setup $setup \
     -body {
         set report [linter_report_procs_without_proc_comment [list $test_file]]
@@ -388,7 +383,7 @@ test linter_report_procs_without_proc_comment-1.0 \
     -result 1
 
 test linter_count_procs_without_proc_comment-1.0 \
-    {Count procs with bodies over a specified number of lines.} \
+    {Count procs that don't have a proc comment.} \
     -setup $setup \
     -body {
         return [linter_count_procs_without_proc_comment [list $test_file]]

--- a/tests/tcl/linter.test
+++ b/tests/tcl/linter.test
@@ -327,4 +327,56 @@ test linter_count_procs_over_length-1.0 \
     } \
     -result 1
 
+test linter_procs_first_line-1.0 \
+    {Test that procs without a #| comment are reported.} \
+    -body {
+        set proc_lines [linter_procs_first_line {
+            proc test_1 {args} {
+                #| Test 1 proc.
+                return 1
+            }
+
+            proc test_2 {args} {
+                return 2
+            }
+        }]
+
+        if { [dict size $proc_lines] > 2 } {
+            error "Expected 2 procs but got [dict size $proc_lines]."
+        }
+
+        set expected [dict create \
+                          test_1 {#| Test 1 proc.}\
+                          test_2 {return 2}]
+
+        dict for {proc_name line} $proc_lines {
+            if { ![dict exists $expected $proc_name] } {
+                error "Proc \"$proc_name\" not expected."
+            } elseif { $line ne [dict get $expected $proc_name] } {
+                error "Expected \"[dict get $expected $proc_name]\" but got \"$line\"."
+            }
+        }
+
+        return 1
+    } \
+    -result 1
+
+test linter_report_procs_without_proc_comment-1.0 \
+    {Test that procs without a #| comment are reported.} \
+    -setup $setup \
+    -body {
+        set report [linter_report_procs_without_proc_comment [list $test_file]]
+
+        return [expr { [string length $report] > 0 }]
+    } \
+    -result 1
+
+test linter_count_procs_without_proc_comment-1.0 \
+    {Count procs with bodies over a specified number of lines.} \
+    -setup $setup \
+    -body {
+        return [linter_count_procs_without_proc_comment [list $test_file]]
+    } \
+    -result 1
+
 cleanupTests

--- a/tests/tcl/linter.test
+++ b/tests/tcl/linter.test
@@ -339,15 +339,31 @@ test linter_procs_first_line-1.0 \
             proc test_2 {args} {
                 return 2
             }
+
+            namespace eval test {
+                namespace export test_3
+                namespace ensemble create
+
+                proc test_3 {args} {
+                    #| Test 3 proc.
+                    return 3
+                }
+
+                proc test_4 {args} {
+                    return 4
+                }
+            }
         }]
 
-        if { [dict size $proc_lines] > 2 } {
-            error "Expected 2 procs but got [dict size $proc_lines]."
+        if { [dict size $proc_lines] != 4 } {
+            error "Expected 4 procs but got [dict size $proc_lines]."
         }
 
         set expected [dict create \
                           test_1 {#| Test 1 proc.}\
-                          test_2 {return 2}]
+                          test_2 {return 2} \
+                          test_3 {#| Test 3 proc.} \
+                          test_4 {return 4}]
 
         dict for {proc_name line} $proc_lines {
             if { ![dict exists $expected $proc_name] } {


### PR DESCRIPTION
Testing
---

### Integration Testing
- [x] Run `scripts/proc-comment-check.tcl`.
- [x] Run `scripts/linting.tcl`.

### Unit Testing
```
tclsh linter.test 
linter.test:	Total	17	Passed	17	Skipped	0	Failed	0
```

## Example Output

### Running scripts/proc-comment-check.tcl
```
Checking procs begin with a #| comment in files that have changed.
The proc linter_test_no_comment in file /home/nick/ci-development/tests/tcl/files/linter_test.tcl does not begin with a #| comment.
```

### Running scripts/linting.tcl (qcode-linter)
```
Checking for procs that do not have a #| comment.
---
The proc linter_test_no_comment in file /home/nick/ci-development/tests/tcl/files/linter_test.tcl does not begin with a #| comment.

1 procs that do not have a #| comment.
```