### PR TITLE
Take Namespaces into Account when Checking Proc Name Prefixes

### DIFF
--- a/tests/tcl/files/linter_test.tcl
+++ b/tests/tcl/files/linter_test.tcl
@@ -12,7 +12,7 @@ proc linter_test {args} {
     return "Hello World"
 }
 
-proc linter_test_two {args} {
+proc ::linter_test_two {args} {
     #| Test proc with a prefix that matches the file name.
 
     return "Hello World"
@@ -24,6 +24,6 @@ proc does_not_start_with_linter_test {args} {
     return "Hello World"
 }
 
-proc linter_test_no_comment {args} {
+proc test::linter_test_no_comment {args} {
     return "Hello World"
 }

--- a/tests/tcl/linter.test
+++ b/tests/tcl/linter.test
@@ -59,6 +59,30 @@ test linter_count_lines_over_length-1.0 \
     } \
     -result 2
 
+test linter_binary_numbers-1.0 \
+    {Get binary numbers.} \
+    -setup $setup \
+    -body {
+        return [linter_binary_numbers 3]
+    } \
+    -result {000 100 010 110 001 101 011 111}
+
+test linter_proc_name_prefixes_from_filename-1.0 \
+    {Get proc name prefixes from a filename.} \
+    -setup $setup \
+    -body {
+        return [linter_proc_name_prefixes_from_filename "test"]
+    } \
+    -result {test}
+
+test linter_proc_name_prefixes_from_filename-1.1 \
+    {Get proc name prefixes from a filename.} \
+    -setup $setup \
+    -body {
+        return [linter_proc_name_prefixes_from_filename "test_file_name"]
+    } \
+    -result {test_file_name test::file_name test_file::name test::file::name}
+
 test linter_report_procs_without_filename_prefix-1.0 \
     {Test proc names not prefixed with the file name are reported.} \
     -setup $setup \
@@ -102,8 +126,8 @@ test linter_proc_names_parse-1.0 \
                       [llength $proc_names] == 4
                       && "proc_names_test_1" in $proc_names
                       && "proc_names_test_2" in $proc_names
-                      && "proc_names_test_3" in $proc_names
-                      && "proc_names_test_4" in $proc_names
+                      && "testing::proc_names_test_3" in $proc_names
+                      && "testing::names::proc_names_test_4" in $proc_names
                   }]
     } \
     -result 1


### PR DESCRIPTION
This change will take into account namespaces when checking proc name prefixes.

### Examples

**Filename:** `is_integer.tcl`
**Examples of valid proc names:**
  * `is_integer`
  * `is::integer`
  * `::is_integer`
  * `::is::integer`
  * `is::integer_test`
  * `test::is_integer`
  * `test::is::integer`
  * `::test::is::integer`

**Filename:** `my_test_file.tcl`
**Examples of valid proc names:**
  * `my_test_file`
  * `my::test_file`
  * `my_test::file`
  * `my::test::file`
  * `my_test_file::linting`
  * `my_test::file::linting`
  * `linter::my::test::file`
  * `linter::my_test_file`
  * `1::2::my::test::file`

Testing
---
```
tclsh linter.test
linter.test:	Total	20	Passed	20	Skipped	0	Failed	0
```