### PR TITLE
Drop Use of Container & Install Dependencies Directly on Ubuntu Runner

### DIFF
--- a/.github/workflows/qcode-ci.yml
+++ b/.github/workflows/qcode-ci.yml
@@ -66,26 +66,24 @@ on:
 jobs:
   linting:
     runs-on: ubuntu-latest
-    container: debian:buster
     env:
       scripts_path: ${{ github.workspace }}/qcode-ci/scripts
     steps:
       - name: Dependencies
         run: |
-          apt-get update
-          apt-get install -y gnupg2 wget git tclsh tcllib tdom tclcurl libpgtcl 
-          echo "deb http://deb.qcode.co.uk buster main" > /etc/apt/sources.list.d/qcode.list
-          wget --quiet -O - http://deb.qcode.co.uk/packages.key | apt-key add -
-          apt-get update
-          apt-get -y install qcode-linter-1.0.0
+          wget http://deb.qcode.co.uk/packages.key
+          gpg --no-default-keyring --keyring ./temp-keyring.gpg --import packages.key
+          gpg --no-default-keyring --keyring ./temp-keyring.gpg --export --output qcode-packages.gpg
+          rm temp-keyring.gpg
+          sudo mv qcode-packages.gpg /etc/apt/keyrings/
+          echo "deb [signed-by=/etc/apt/keyrings/qcode-packages.gpg] http://deb.qcode.co.uk buster main" | sudo tee /etc/apt/sources.list.d/qcode.list
+          sudo apt-get update
+          sudo apt-get install -y tcl tcllib tdom tclcurl libpgtcl qcode-linter-1.0.0
 
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Add Workspace to Git Safe Directories
-        run: git config --system --add safe.directory ${{ github.workspace }}
 
       - name: Checkout Qcode CI
         uses: actions/checkout@v3

--- a/scripts/file-length-check.tcl
+++ b/scripts/file-length-check.tcl
@@ -13,3 +13,4 @@ set count [files_over_length_count $tcl_files $max_lines]
 if { $count > 0 } {
     exit 1
 }
+

--- a/scripts/file-length-check.tcl
+++ b/scripts/file-length-check.tcl
@@ -13,4 +13,3 @@ set count [files_over_length_count $tcl_files $max_lines]
 if { $count > 0 } {
     exit 1
 }
-


### PR DESCRIPTION
Ready to be merged.

There's no issue with installing the qcode-linter Debian package here since the installation is very simple and the location of scripts and Tcl packages is the same between Debian Buster and Ubuntu 22.04.

Testing
---
The check was successfully run: https://github.com/qcode-software/ci-development/actions/runs/5005352572/jobs/8969190045

I also used WSL running Ubuntu 22.04 to set up the qcode repo in apt, installed qcode-tcl & qcode-linter, and used the packages via tclsh.

