### PR TITLE
Use qcode-linter v2.3.0

### DIFF
--- a/.github/workflows/qcode-ci.yml
+++ b/.github/workflows/qcode-ci.yml
@@ -78,7 +78,7 @@ jobs:
           sudo mv qcode-packages.gpg /etc/apt/keyrings/
           echo "deb [signed-by=/etc/apt/keyrings/qcode-packages.gpg] https://debian.qcode.co.uk buster main" | sudo tee /etc/apt/sources.list.d/qcode.list
           sudo apt-get update
-          sudo apt-get install -y tcl tcllib tdom tclcurl libpgtcl qcode-linter-2.1.0
+          sudo apt-get install -y tcl tcllib tdom tclcurl libpgtcl qcode-linter-2.3.0
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
v2.2.0 matches namespaces when checking for unit tests.
v2.3.0 added support "/" and "." in test names.